### PR TITLE
Added missing prefix for xDB aliases

### DIFF
--- a/src/searchstax-sitecore-xconnect.ps1
+++ b/src/searchstax-sitecore-xconnect.ps1
@@ -50,7 +50,7 @@ function Create-XConnect-Alias($solr, $nodeCount) {
 
     foreach($collection in $collectionsXConnect){
         $collection | Write-Host
-        $url = -join($solr, "admin/collections?action=CREATEALIAS&name=",$xConnectCollectionAlias[$collection],"&collections=",$collection)
+        $url = -join($solr, "admin/collections?action=CREATEALIAS&name=",$sitecorePrefix,"_",$xConnectCollectionAlias[$collection],"&collections=",$collection)
         if ($solrUsername.length -gt 0){
             Invoke-WebRequest -Uri $url -Credential $credential
         }


### PR DESCRIPTION
The xDB aliases were missing the sitecore prefix. Our environment was expecting all of the solr indexes to have the same prefix (`sitecore_`) but the xDB aliases were missing it and it was throwing errors. 

I've added it to remain consistent.