### PR TITLE
Update sitecore-searchstax-connector.ps1 for isConfigureXConnect

### DIFF
--- a/sitecore-searchstax-connector.ps1
+++ b/sitecore-searchstax-connector.ps1
@@ -247,6 +247,31 @@ elseif($global:isConfigureXP -eq "true") {
 
     $global:coll = $collectionsXM + $global:collectionsMarketing
 }
+elseif($global:isConfigureXConnect -eq "true") {
+    if ($sitecoreVersion -eq "9.0.2") {
+        $solrVersion = "6"
+        $global:isUniqueConfigs= $true
+    } elseif ($sitecoreVersion -eq "9.1.1") {
+        $solrVersion = "7.2.1"
+    } elseif ($sitecoreVersion -eq "9.2.0") {
+        $solrVersion = "7.5.0"
+    } elseif ($sitecoreVersion -eq "9.3.0") {
+        $solrVersion = "8.1.1"
+    } elseif ($sitecoreVersion -like "10.0.*") {
+        $solrVersion = "8.4.0"
+    } elseif ($sitecoreVersion -like "10.1.*") {
+        $solrVersion = "8.4.0"
+    } elseif ($sitecoreVersion -like "10.2.*") {
+        $solrVersion = "8.8.2"
+    } elseif ($sitecoreVersion -like "10.3.*") {
+        $solrVersion = "8.11.2"
+    } elseif ($sitecoreVersion -like "10.4.*") {
+        $solrVersion = "8.11.2"
+    }
+     else {
+        Write-Error -Message "Unsupported sitecore version specified. Supported versions are 9.0.2, 9.1.1, 9.2.0, 9.3.0, 10.0.*, 10.1.*, 10.2.*, 10.3.*, 10.4.*" -ErrorAction Stop
+    }
+}
 
 if ($global:isSxa -eq "true") {
     $global:sxaColl = $collectionsSXA


### PR DESCRIPTION
The sitecoreVersion was not set when only isConfigureXConnect is true. This way you could not add XCONNECT as only configMode.